### PR TITLE
Add PyOpenCL OpenCL utility module and tests

### DIFF
--- a/ready/__init__.py
+++ b/ready/__init__.py
@@ -1,0 +1,1 @@
+"""Ready Python utilities."""

--- a/ready/opencl_utils.py
+++ b/ready/opencl_utils.py
@@ -1,0 +1,78 @@
+"""Python utilities for working with OpenCL via PyOpenCL.
+
+This module translates a subset of the C++ implementation found in
+``src/readybase/OpenCL_utils.{hpp,cpp}``.
+"""
+
+from __future__ import annotations
+
+
+def IsOpenCLAvailable() -> bool:
+    """Return ``True`` if at least one OpenCL device is available.
+
+    The function attempts to enumerate OpenCL platforms and their devices
+    using :mod:`pyopencl`.  Any import or runtime errors are treated as
+    the absence of OpenCL support.
+    """
+    try:
+        import pyopencl as cl  # type: ignore
+    except Exception:
+        return False
+    try:
+        platforms = cl.get_platforms()
+    except Exception:
+        return False
+    for platform in platforms:
+        try:
+            devices = platform.get_devices()
+        except Exception:
+            continue
+        if devices:
+            return True
+    return False
+
+
+def throwOnError(ret: int, message: str) -> None:
+    """Raise ``RuntimeError`` if ``ret`` represents an OpenCL error."""
+    if ret == 0:
+        return
+    err_str = str(ret)
+    try:
+        import pyopencl as cl  # type: ignore
+        try:
+            err_str = cl.status_code.to_string(ret)  # type: ignore[attr-defined]
+        except Exception:
+            err_str = str(ret)
+    except Exception:
+        pass
+    raise RuntimeError(f"{message}{err_str}")
+
+
+def GetOpenCLDiagnostics() -> str:
+    """Return a human readable description of the available OpenCL devices."""
+    try:
+        import pyopencl as cl  # type: ignore
+    except Exception as e:
+        return f"Failed to import PyOpenCL: {e}"
+    try:
+        platforms = cl.get_platforms()
+    except Exception as e:
+        return f"Failed to get OpenCL platforms: {e}"
+    if not platforms:
+        return "No OpenCL platforms available"
+    lines = [f"Found {len(platforms)} platform(s):"]
+    for idx, platform in enumerate(platforms, 1):
+        name = getattr(platform, "name", "Unknown")
+        lines.append(f"Platform {idx}: {name}")
+        try:
+            devices = platform.get_devices()
+        except Exception as e:
+            lines.append(f"  Failed to get devices: {e}")
+            continue
+        if not devices:
+            lines.append("  No devices")
+            continue
+        for jdx, device in enumerate(devices, 1):
+            dname = getattr(device, "name", "Unknown")
+            lines.append(f"  Device {jdx}: {dname}")
+    return "\n".join(lines)

--- a/tests/test_opencl_utils.py
+++ b/tests/test_opencl_utils.py
@@ -1,0 +1,47 @@
+import sys, os, types, importlib
+from unittest import mock
+import pytest
+
+ROOT=os.path.dirname(os.path.dirname(__file__))
+if ROOT not in sys.path: sys.path.insert(0, ROOT)
+
+def fake_module(platforms):
+    return types.SimpleNamespace(get_platforms=lambda: platforms,
+                                 status_code=types.SimpleNamespace(SUCCESS=0,to_string=lambda c:f"ERR{c}"))
+
+class D:
+    def __init__(self,name="FakeDevice"): self.name=name
+
+class P:
+    def __init__(self,devices=None): self.devices=devices or []
+    def get_devices(self): return self.devices
+
+def test_available_with_device():
+    fake_cl=fake_module([P([D()])])
+    with mock.patch.dict(sys.modules,{"pyopencl":fake_cl}):
+        import ready.opencl_utils as oc; importlib.reload(oc)
+        assert oc.IsOpenCLAvailable()
+        assert "Device 1" in oc.GetOpenCLDiagnostics()
+
+def test_unavailable_no_device():
+    fake_cl=fake_module([P([])])
+    with mock.patch.dict(sys.modules,{"pyopencl":fake_cl}):
+        import ready.opencl_utils as oc; importlib.reload(oc)
+        assert not oc.IsOpenCLAvailable()
+        assert "No devices" in oc.GetOpenCLDiagnostics()
+
+def test_no_platforms():
+    fake_cl=fake_module([])
+    with mock.patch.dict(sys.modules,{"pyopencl":fake_cl}):
+        import ready.opencl_utils as oc; importlib.reload(oc)
+        assert not oc.IsOpenCLAvailable()
+        assert "No OpenCL platforms available" in oc.GetOpenCLDiagnostics()
+
+def test_throw_on_error():
+    fake_cl=fake_module([])
+    with mock.patch.dict(sys.modules,{"pyopencl":fake_cl}):
+        import ready.opencl_utils as oc; importlib.reload(oc)
+        oc.throwOnError(0,"ok")
+        with pytest.raises(RuntimeError) as err:
+            oc.throwOnError(1,"fail ")
+    assert str(err.value)=="fail ERR1"


### PR DESCRIPTION
## Summary
- Translate C++ OpenCL utilities into a Python module.
- Provide device availability check, error translation, and diagnostic reporting via PyOpenCL.
- Add unit tests using mocked PyOpenCL implementations for device presence/absence.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0a0f640f4832c89a1b03a741b5d97